### PR TITLE
[33] Show If Nearest Station Is Favorited

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -5,5 +5,6 @@ class DashboardsController < ApplicationController
     @user_address = "#{@user_info[:street_address]} #{@user_info[:city]}, #{@user_info[:state]} #{@user_info[:zip_code]}"
     @nearest_stations = StationFacade.get_stations(@user_address)
     @favorite_stations = UserFacade.get_favorite_stations(session[:token])
+    @favorites = @favorite_stations.map { | station | station.api_id }
   end
 end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -33,7 +33,11 @@
           <% @nearest_stations.each_with_index do |station, index| %>
           <% cache station.api_id do %>
             <div id="nearest-station-<%= index %>">
-              <h3><%= link_to "#{station.name}", station_path(station.api_id), method: :get %></h3>
+              <% if @favorites.include?(station.api_id) %>
+                <h3><%= link_to "#{station.name} - favorited", station_path(station.api_id), method: :get %></h3>
+              <% else %>
+                <h3><%= link_to "#{station.name}", station_path(station.api_id), method: :get %></h3>
+              <% end %>
               <p><%= station.street_address %></p>
               <p><%= "#{station.city}, #{station.state} #{station.zip_code}"  %></p>
               <p>Status: <%= station.status %></p>

--- a/spec/features/dashboards/show_spec.rb
+++ b/spec/features/dashboards/show_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Dashboard Page" do
         within(".nearest-stations") do
           expect(page).to have_content("Here are the 14 stations nearest to 3722 Crenshaw Blvd. Los Angeles, CA 90016")
         end
-        
+
         within("#nearest-station-0") do
           expect(page).to have_content(@station1[:name])
           expect(page).to have_content(@station1[:street_address])
@@ -91,6 +91,25 @@ RSpec.describe "Dashboard Page" do
       it "redirects to dashboard when user is logged in and tries to visit the home page", :vcr do
         visit root_path
         expect(current_path).to eq(dashboard_path)
+      end
+
+      context 'nearest stations shows a favorite station' do
+        it "displays 'favorited' if already saved as favorite" do
+          @station1 =  {
+                          "name": "G&M OIL CHEVRON #111",
+                          "distance": 1.13745,
+                          "status": "Available",
+                          "hours": "Mon 12:00am - 12:00am; Tue 12:00am - 12:00am; Wed 12:00am - 12:00am; Thu 12:00am - 12:00am; Fri 12:00am - 12:00am; Sat 12:00am - 12:00am; Sun 12:00am - 12:00am",
+                          "ev_network": "ChargePoint Network",
+                          "street_address": "3600 South La Brea Ave",
+                          "city": "Los Angeles",
+                          "state": "CA",
+                          "zip_code": "90016"
+                        }
+          within("#nearest-station-0") do
+            expect(page).to have_content("#{@station1[:name]} - favorited")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### 🚨 Problem:
 <!-- What needed changed? bug? refactor? feature? Please describe the problem you're trying to solve -->
We are not letting the user know if one of the nearest stations is already saved as a favorite station.
- I will start with a simple string `favorited` next to the station name
- Ideally, it will be a star icon (preferably filled in so that in the future they can toggle that to save as favorite)

### 💡 Solution:
<!-- how are you solving this simply and elegantly? Describe if necessary or check corresponding boxes -->
* [x] New feature
* [ ] Bug fix
* [ ] Refactor
* [ ] Other

### 🤔 Testing:

* [x] Wrote new tests
* [ ] Successfully ran tests
* [ ] All new and existing tests passed

### ✅ Checklist:

* [ ] I have reviewed my code
* [ ] My code has no unused/commented out code
* [ ] I have commented my code for hard-to-understand areas
* [ ] I have fully tested my code
* [ ] I have made corresponding changes to the documentation

--------------------------------------------------------------------------------
**🦥 Test Coverage:**

* [ ] < 90%
* [ ] 90-99%
* [ ] 100%
